### PR TITLE
Fix conditional compilation for Windows, avoid unstable #[doc(cfg)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,11 +688,9 @@ impl WinOsString for OsString {
     }
 }
 
+//#[doc(cfg(feature = "windows"))]
 #[cfg(target_os = "windows")]
-#[doc(cfg(windows))]
-#[doc(cfg(features = "windows"))]
-#[cfg(target_os = "windows")]
-#[cfg(features = "windows")]
+#[cfg(feature = "windows")]
 /// This uses unsafe transmutation. However, the lifetimes of passed
 /// in values are respected and all byte slices are checked before
 /// being turned into an `OsStr`. For example, this fails to compile:
@@ -723,7 +721,7 @@ impl WinOsString for OsString {
 ///
 /// ```should_panic
 /// #[cfg(target_os = "windows")]
-/// #[cfg(features = "windows")]
+/// #[cfg(feature = "windows")]
 /// fn will_panic() {
 ///     use std::ffi::{OsString, OsStr};
 ///     use crate::osstrtools::{Bytes, WinOsStringExt, WinOsStrExt};


### PR DESCRIPTION
Should fix part of the problem in https://github.com/rabite0/osstrtools/issues/1.

More compile errors remain:
```
error[E0425]: cannot find value `bytes` in this scope
   --> src\lib.rs:752:19
    |
752 |         unsafe { (bytes as *const _).cast:() }
    |                   ^^^^^                  - help: maybe you meant to write a path separator here: `::`
    |                   |
    |                   not found in this scope

error[E0699]: the type of this value must be known to call a method on a raw pointer on it
   --> src\lib.rs:747:38
    |
747 |         unsafe { (bytes as *const _).cast() }
    |                                      ^^^^
```