### PR TITLE
Fix typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -751,7 +751,7 @@ impl WinOsStr for OsStr {
 
     fn as_bytes<'s>(&'s self) -> &'s [u8] {
         // This should be fine in any case, as OsStr is just a &[u8]
-        unsafe { (bytes as *const _).cast:() }
+        unsafe { (bytes as *const _).cast() }
     }
 }
 


### PR DESCRIPTION
Started failing with rust 1.71.0

```
> error: expected one of `(`, `.`, `::`, `;`, `?`, `}`, or an operator, found `:`
>    --> /build/cargo-vendor-dir/osstrtools-0.2.2/src/lib.rs:754:42
>     |
> 754 |         unsafe { (bytes as *const _).cast:() }
>     |                                          ^ expected one of 7 possible tokens
>
> error: could not compile `osstrtools` (lib) due to previous error
```

Typo was added in 1179a97